### PR TITLE
Add autofill functionality for website info

### DIFF
--- a/admin/class-frak-admin.php
+++ b/admin/class-frak-admin.php
@@ -98,8 +98,12 @@ class Frak_Admin {
     }
 
     private function render_settings_page() {
-        $app_name = get_option('frak_app_name', 'Your App Name');
-        $logo_url = get_option('frak_logo_url', '');
+        // Get default values from WordPress site info
+        $default_app_name = get_bloginfo('name');
+        $default_logo_url = $this->get_site_icon_url();
+        
+        $app_name = get_option('frak_app_name', $default_app_name);
+        $logo_url = get_option('frak_logo_url', $default_logo_url);
         $custom_config = get_option('frak_custom_config', '');
         $enable_tracking = get_option('frak_enable_purchase_tracking', 0);
         $enable_button = get_option('frak_enable_floating_button', 0);
@@ -111,6 +115,27 @@ class Frak_Admin {
         }
         
         include FRAK_PLUGIN_DIR . 'admin/views/settings-page.php';
+    }
+
+    private function get_site_icon_url() {
+        $site_icon_id = get_option('site_icon');
+        if ($site_icon_id) {
+            $site_icon_url = wp_get_attachment_image_url($site_icon_id, 'full');
+            if ($site_icon_url) {
+                return $site_icon_url;
+            }
+        }
+        
+        // Fallback: try to get logo from theme customizer
+        $custom_logo_id = get_theme_mod('custom_logo');
+        if ($custom_logo_id) {
+            $custom_logo_url = wp_get_attachment_image_url($custom_logo_id, 'full');
+            if ($custom_logo_url) {
+                return $custom_logo_url;
+            }
+        }
+        
+        return '';
     }
 
     private function get_default_config($app_name, $logo_url) {

--- a/admin/views/settings-page.php
+++ b/admin/views/settings-page.php
@@ -15,6 +15,10 @@
                 <td>
                     <input type="text" id="frak_app_name" name="frak_app_name" 
                            value="<?php echo esc_attr($app_name); ?>" class="regular-text">
+                    <button type="button" id="autofill_app_name" class="button button-secondary" style="margin-left: 10px;">
+                        Use Site Name
+                    </button>
+                    <p class="description">Current site name: <strong><?php echo esc_html(get_bloginfo('name')); ?></strong></p>
                 </td>
             </tr>
             <tr>
@@ -24,6 +28,23 @@
                 <td>
                     <input type="url" id="frak_logo_url" name="frak_logo_url" 
                            value="<?php echo esc_url($logo_url); ?>" class="regular-text">
+                    <button type="button" id="autofill_logo_url" class="button button-secondary" style="margin-left: 10px;">
+                        Use Site Icon
+                    </button>
+                    <?php
+                    $site_icon_id = get_option('site_icon');
+                    $custom_logo_id = get_theme_mod('custom_logo');
+                    if ($site_icon_id || $custom_logo_id): ?>
+                        <p class="description">
+                            <?php if ($site_icon_id): ?>
+                                Site icon available
+                            <?php elseif ($custom_logo_id): ?>
+                                Custom logo available
+                            <?php endif; ?>
+                        </p>
+                    <?php else: ?>
+                        <p class="description">No site icon or custom logo found. <a href="<?php echo admin_url('customize.php'); ?>" target="_blank">Set one in Customizer</a></p>
+                    <?php endif; ?>
                 </td>
             </tr>
             <tr>
@@ -114,6 +135,25 @@ jQuery(document).ready(function($) {
         }
     });
 
+    // WordPress site information for autofill
+    var wpSiteInfo = {
+        name: <?php echo json_encode(get_bloginfo('name')); ?>,
+        logoUrl: <?php 
+            $site_icon_id = get_option('site_icon');
+            $logo_url = '';
+            if ($site_icon_id) {
+                $logo_url = wp_get_attachment_image_url($site_icon_id, 'full');
+            }
+            if (!$logo_url) {
+                $custom_logo_id = get_theme_mod('custom_logo');
+                if ($custom_logo_id) {
+                    $logo_url = wp_get_attachment_image_url($custom_logo_id, 'full');
+                }
+            }
+            echo json_encode($logo_url ?: '');
+        ?>
+    };
+
     function updateConfig() {
         var appName = $('#frak_app_name').val();
         var logoUrl = $('#frak_logo_url').val();
@@ -136,6 +176,19 @@ jQuery(document).ready(function($) {
         var enabled = $('#frak_enable_floating_button').is(':checked');
         $('#frak_show_reward, #frak_button_classname').prop('disabled', !enabled);
     }
+
+    // Autofill functionality
+    $('#autofill_app_name').on('click', function() {
+        if (wpSiteInfo.name) {
+            $('#frak_app_name').val(wpSiteInfo.name).trigger('input');
+        }
+    });
+
+    $('#autofill_logo_url').on('click', function() {
+        if (wpSiteInfo.logoUrl) {
+            $('#frak_logo_url').val(wpSiteInfo.logoUrl).trigger('input');
+        }
+    });
 
     $('#frak_app_name, #frak_logo_url').on('input', updateConfig);
     $('#frak_enable_floating_button').on('change', toggleFloatingButtonSettings);


### PR DESCRIPTION
## Summary
- Added autofill functionality to automatically populate app name and logo URL fields with WordPress site information
- Implemented manual autofill buttons for easy one-click population of fields
- Added intelligent site icon detection with fallback to custom theme logo

## Changes
- Modified `admin/class-frak-admin.php` to:
  - Use WordPress site name and icon as default values when fields are empty
  - Added `get_site_icon_url()` method that checks for site icon and falls back to custom theme logo
  
- Enhanced `admin/views/settings-page.php` with:
  - "Use Site Name" button for the App Name field
  - "Use Site Icon" button for the Logo URL field  
  - Display of current site name
  - Status indicators showing icon availability with link to WordPress Customizer

## Test plan
- [ ] Test on fresh WordPress installation to verify defaults are populated
- [ ] Test autofill buttons work correctly when site has:
  - [ ] Both site icon and custom logo
  - [ ] Only site icon
  - [ ] Only custom logo
  - [ ] Neither icon nor logo
- [ ] Verify configuration updates automatically when values change
- [ ] Ensure backwards compatibility with existing installations

🤖 Generated with [Claude Code](https://claude.ai/code)